### PR TITLE
Fix item drops outside of permissible qlvl

### DIFF
--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -67,7 +67,7 @@ enum _item_indexes : int16_t { // TODO defines all indexes in AllItemsList
 	IDI_GREYSUIT,
 	IDI_SORCERER_DIABLO = IDI_SORCERER,
 
-	IDI_LAST = 155,
+	IDI_LAST = 157,
 	IDI_NONE = -1,
 };
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1398,8 +1398,8 @@ int RndTypeItems(ItemType itemType, int imid, int lvl)
 		bool okflag = true;
 		if (AllItemsList[i].iRnd == IDROP_NEVER)
 			okflag = false;
-		/*if (lvl * 2 < AllItemsList[i].iMinMLvl)
-		    okflag = false;*/
+		if (lvl * 2 < AllItemsList[i].iMinMLvl)
+			okflag = false;
 		if (AllItemsList[i].itype != itemType)
 			okflag = false;
 		if (imid != -1 && AllItemsList[i].iMiscId != imid)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3763,16 +3763,10 @@ void OperateArmorStand(int pnum, int i, bool sendmsg)
 	}
 	SetRndSeed(Objects[i]._oRndSeed);
 	bool uniqueRnd = (GenerateRnd(2) != 0);
-	if (currlevel <= 5) {
+	if (currlevel < 10) {
 		CreateTypeItem(Objects[i].position, true, ItemType::LightArmor, IMISC_NONE, sendmsg, false);
-	} else if (currlevel >= 6 && currlevel <= 9) {
-		CreateTypeItem(Objects[i].position, uniqueRnd, ItemType::MediumArmor, IMISC_NONE, sendmsg, false);
-	} else if (currlevel >= 10 && currlevel <= 12) {
-		CreateTypeItem(Objects[i].position, false, ItemType::HeavyArmor, IMISC_NONE, sendmsg, false);
-	} else if (currlevel >= 13 && currlevel <= 16) {
-		CreateTypeItem(Objects[i].position, true, ItemType::HeavyArmor, IMISC_NONE, sendmsg, false);
-	} else if (currlevel >= 17) {
-		CreateTypeItem(Objects[i].position, true, ItemType::HeavyArmor, IMISC_NONE, sendmsg, false);
+	} else {
+		CreateTypeItem(Objects[i].position, true, ItemType::MediumArmor, IMISC_NONE, sendmsg, false);
 	}
 	if (pnum == MyPlayerId)
 		NetSendCmdParam1(false, CMD_OPERATEOBJ, i);


### PR DESCRIPTION
Commit 5f20ef5 had commented out the minLevel restriction for random item types. Restored this so item stands drop permissible items.